### PR TITLE
Fix typo in constructor assignment

### DIFF
--- a/blur-clone/contracts/NFTMarketplace.sol
+++ b/blur-clone/contracts/NFTMarketplace.sol
@@ -14,7 +14,7 @@ contract NFTMarketplace is ReentrancyGuard {
     address public owner;
 
     constructor() {
-        owner == msg.sender;
+        owner = msg.sender;
     }
 
     struct MarketItem {


### PR DESCRIPTION
This commit fixes a typo in the constructor of the NFT marketplace contract. The original code used '==' instead of '=', which resulted in an incorrect comparison and failed to assign the correct value to the 'owner' variable. The updated code uses the correct assignment operator, which ensures that the 'owner' variable is properly initialized with the address of the contract creator.